### PR TITLE
連続ログインが14日以上になった場合の対応

### DIFF
--- a/app/src/mihoyo.ts
+++ b/app/src/mihoyo.ts
@@ -93,7 +93,12 @@ export const accessGenshinImpactDailyAndClaimReward = async (
 
   await acceptCookies(page);
 
-  await page.getByText('さらに表示').click();
+  // さらに表示があればクリック
+  const showMore = page.getByText('さらに表示');
+  if (await showMore.count()) {
+    await showMore.click();
+  }
+
   await page.screenshot({ path: GENSHIN_IMPACT_DAILY_TOP_IMAGE });
   await lineNotify(
     '原神のログインボーナス受け取り処理を開始',


### PR DESCRIPTION
# 概要
連続ログインが14日以上になった場合、更に表示ボタンが消える

ボタンがあったばあい押下するように修正する